### PR TITLE
feat: always log migration results

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -6,7 +6,7 @@ import {Kysely, MigrationResultSet, Migrator, NO_MIGRATIONS} from 'kysely'
 function showResults({ error, results }: MigrationResultSet) {
   if (results) {
     results.forEach((it) => console.log(`> ${it.status}: ${it.migrationName} (${it.direction})`))
-    if (!results.length) {
+    if (results.length === 0) {
       console.log('> No pending migrations to execute')
     }
   }

--- a/src/run.ts
+++ b/src/run.ts
@@ -4,11 +4,16 @@ import { program } from 'commander'
 import {Kysely, MigrationResultSet, Migrator, NO_MIGRATIONS} from 'kysely'
 
 function showResults({ error, results }: MigrationResultSet) {
+  if (results) {
+    results.forEach((it) => console.log(`> ${it.status}: ${it.migrationName} (${it.direction})`))
+    if (!results.length) {
+      console.log('> No pending migrations to execute')
+    }
+  }
   if (error) {
     console.error(error)
     process.exit(1)
   }
-  results?.forEach((it) => console.log(`> ${it.migrationName}`))
 }
 
 export function run(


### PR DESCRIPTION
Closes https://github.com/acro5piano/kysely-migration-cli/issues/9

This PR moves `console.log()` before `process.exit(1)` on error in `showResults()` to ensure that migrations logs are always available.