### PR TITLE
Update readme examples to work with Kysely

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,12 @@ Create a migration script as shown below:
 ```typescript
 // scripts/migrate.ts
 
+import * as path from 'path'
+import { promises as fs } from 'fs';
 import { Kysely, Migrator, PostgresDialect, FileMigrationProvider } from 'kysely'
 import { run } from 'kysely-migration-cli'
+
+const migrationFolder = new URL('./migrations', import.meta.url).pathname
 
 const db = new Kysely<any>({
   dialect: new PostgresDialect({
@@ -34,10 +38,14 @@ const db = new Kysely<any>({
 
 const migrator = new Migrator({
   db,
-  provider: new FileMigrationProvider('./migrations'),
+  provider: new FileMigrationProvider({
+    fs,
+    path,
+    migrationFolder,
+  }),
 })
 
-run(db, migrator)
+run(db, migrator, migrationFolder)
 ```
 
 Then run:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Create a migration script as shown below:
 // scripts/migrate.ts
 
 import * as path from 'path'
-import { promises as fs } from 'fs';
+import { promises as fs } from 'fs'
+import pg from 'pg'
 import { Kysely, Migrator, PostgresDialect, FileMigrationProvider } from 'kysely'
 import { run } from 'kysely-migration-cli'
 
@@ -32,7 +33,9 @@ const migrationFolder = new URL('./migrations', import.meta.url).pathname
 
 const db = new Kysely<any>({
   dialect: new PostgresDialect({
-    connectionString: process.env.DATABASE_URL,
+    pool: new pg.Pool({
+      connectionString: process.env.DATABASE_URL,
+    }),
   }),
 })
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,11 @@ import pg from 'pg'
 import { Kysely, Migrator, PostgresDialect, FileMigrationProvider } from 'kysely'
 import { run } from 'kysely-migration-cli'
 
+// For ESM environment
 const migrationFolder = new URL('./migrations', import.meta.url).pathname
+
+// For CJS environment
+// const migrationFolder = path.join(__dirname, './migrations')
 
 const db = new Kysely<any>({
   dialect: new PostgresDialect({


### PR DESCRIPTION
It looks like the API for Kysely has been updated but the README still has an old example. This updates the readme so that the script continues to work.

See: https://www.kysely.dev/docs/migrations#running-migrations

```typescript
  const db = new Kysely<Database>({
    dialect: new PostgresDialect({
      pool: new Pool({
        host: 'localhost',
        database: 'kysely_test',
      }),
    }),
  })
```

and

```typescript
// This needs to be an absolute path.
migrationFolder: path.join(__dirname, 'some/path/to/migrations'),
```